### PR TITLE
native datepickers not working

### DIFF
--- a/app/views/issues/_attributes.html.erb
+++ b/app/views/issues/_attributes.html.erb
@@ -48,14 +48,14 @@
 
 <% if @issue.safe_attribute? 'start_date' %>
 <p id="start_date_area">
-  <%= f.text_field(:start_date, :size => 10, :required => @issue.required_attribute?('start_date')) %>
+  <%= f.date_field(:start_date, :size => 10, :required => @issue.required_attribute?('start_date')) %>
   <%= calendar_for('issue_start_date') %>
 </p>
 <% end %>
 
 <% if @issue.safe_attribute? 'due_date' %>
 <p id="due_date_area">
-  <%= f.text_field(:due_date, :size => 10, :required => @issue.required_attribute?('due_date')) %>
+  <%= f.date_field(:due_date, :size => 10, :required => @issue.required_attribute?('due_date')) %>
   <%= calendar_for('issue_due_date') %>
 </p>
 <% end %>


### PR DESCRIPTION
native datepickers for start_date and due_date were not working when this plugin was installed.